### PR TITLE
Retrieving individual ibes estimates via QAD and fixing a big

### DIFF
--- a/ctrlaltdata/panel_constructors.py
+++ b/ctrlaltdata/panel_constructors.py
@@ -401,7 +401,7 @@ def get_gic_panel(*args, index='sp_500', gic='', since=None, until=None, frequen
                                   **kwargs)
     else:
         raise ValueError(f'Index {index} not supported.')
-    panel = panel.features.gic_code(*args, source=source, **kwargs)
+    panel = panel.features.gic(*args, source=source, **kwargs)
     if gic:
         panel = panel.loc[panel.gic.apply(lambda x: x[:len(gic)]) == gic]
 

--- a/ctrlaltdata/qad/api.py
+++ b/ctrlaltdata/qad/api.py
@@ -1287,7 +1287,7 @@ class Features():
 
         EARNINGS PER SHARE represents the earnings for the 12 months ended the last calendar quarter of the year
         for U.S. corporations and the fiscal year for non-U.S. corporations It represents the fully diluted earnings per
-        share (field 05290) for US companies and basic earnings per share (field 05210) for other companies.
+        share (field 05290 Annual, 18440 else) for US companies and basic earnings per share (field 05210 Annual, 18420 else) for other companies.
 
         :param period: str, period type (NOT pandas standard) to retrive net cash from,
             either annual type ['A','B','G'] or quarterly type ["E","Q","H","I","R","@"]
@@ -1297,13 +1297,20 @@ class Features():
         """
         self._warn_if_overwriting_and_delete('earnings_per_share')
         qad = ResourceManager().qad
-
-        if diluted_earnings:
-            feature_code = 5290
-            db_column_name = 'earnings_per_share___fully_diluted_shares___year'
+        
+        if period=='A':
+            if diluted_earnings:
+                feature_code = 5290
+                db_column_name = 'earnings_per_share___fully_diluted_shares___year'
+            else:
+                feature_code = 5210
+                db_column_name = 'earnings_per_share___basic___year'
+        elif diluted_earnings:
+            feature_code=18440
+            db_column_name = 'earnings_per_share___fully_diluted___fiscal'
         else:
-            feature_code = 5210
-            db_column_name = 'earnings_per_share___basic___year'
+            feature_code=18420
+            db_column_name = 'earnings_per_share___fiscal___basic'
 
         feature_panel = qad.get_worldscope_feature(self._obj, feature_name='earnings_per_share',
                                                    feature_code=feature_code,


### PR DESCRIPTION
This PR adds the ability to pull individual IBES estimates from QAD. It also fixes a bug where if ran succesively for different metrics (but with different optional columns), the columns filter merge_as_of would fail.